### PR TITLE
Refactor to load RTEs generically instead of TinyMCE specific.

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -27,123 +27,12 @@
  */
 $settings = array();
 
-/*
-$settings['gallery.']= $modx->newObject('modSystemSetting');
-$settings['gallery.']->fromArray(array(
-    'key' => 'gallery.',
-    'value' => '',
-    'xtype' => 'textfield',
-    'namespace' => 'gallery',
-    'area' => '',
-),'',true,true);
-*/
-
-
-/* Settings for the TinyMCE integration */
+/* Settings for the RTE integration */
 $settings['faqman.use_richtext']= $modx->newObject('modSystemSetting');
 $settings['faqman.use_richtext']->fromArray(array(
     'key' => 'faqman.use_richtext',
     'value' => true,
     'xtype' => 'combo-boolean',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.width']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.width']->fromArray(array(
-    'key' => 'faqman.tiny.width',
-    'value' => '95%',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.height']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.height']->fromArray(array(
-    'key' => 'faqman.tiny.height',
-    'value' => 200,
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.buttons1']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.buttons1']->fromArray(array(
-    'key' => 'faqman.tiny.buttons1',
-    'value' => 'undo,redo,selectall,pastetext,pasteword,charmap,separator,image,modxlink,unlink,media,separator,code,help',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.buttons2']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.buttons2']->fromArray(array(
-    'key' => 'faqman.tiny.buttons2',
-    'value' => 'bold,italic,underline,strikethrough,sub,sup,separator,bullist,numlist,outdent,indent,separator,justifyleft,justifycenter,justifyright,justifyfull',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.buttons3']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.buttons3']->fromArray(array(
-    'key' => 'faqman.tiny.buttons3',
-    'value' => 'styleselect,formatselect,separator,styleprops',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.buttons4']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.buttons4']->fromArray(array(
-    'key' => 'faqman.tiny.buttons4',
-    'value' => '',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.buttons5']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.buttons5']->fromArray(array(
-    'key' => 'faqman.tiny.buttons5',
-    'value' => '',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.custom_plugins']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.custom_plugins']->fromArray(array(
-    'key' => 'faqman.tiny.custom_plugins',
-    'value' => '',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.theme']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.theme']->fromArray(array(
-    'key' => 'faqman.tiny.theme',
-    'value' => '',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.theme_advanced_blockformats']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.theme_advanced_blockformats']->fromArray(array(
-    'key' => 'faqman.tiny.theme_advanced_blockformats',
-    'value' => '',
-    'xtype' => 'textfield',
-    'namespace' => 'faqman',
-    'area' => 'TinyMCE',
-),'',true,true);
-
-$settings['faqman.tiny.theme_advanced_css_selectors']= $modx->newObject('modSystemSetting');
-$settings['faqman.tiny.theme_advanced_css_selectors']->fromArray(array(
-    'key' => 'faqman.tiny.theme_advanced_css_selectors',
-    'value' => '',
-    'xtype' => 'textfield',
     'namespace' => 'faqman',
     'area' => 'TinyMCE',
 ),'',true,true);

--- a/assets/components/faqman/js/mgr/widgets/items.grid.js
+++ b/assets/components/faqman/js/mgr/widgets/items.grid.js
@@ -237,7 +237,7 @@ faqMan.window.CreateItem = function(config) {
         title: _('faqman.item_create')
         ,id: this.ident
         ,autoHeight: true
-        ,width: 600
+        ,width: 650
         ,url: faqMan.config.connector_url
         ,closeAction: 'close'
         ,baseParams: {
@@ -256,11 +256,12 @@ faqMan.window.CreateItem = function(config) {
             ,name: 'answer'
             ,id: 'faqman-'+this.ident+'-answer'
             ,width: '94%'
+            ,height: 250
         }]
     });
     faqMan.window.CreateItem.superclass.constructor.call(this,config);
     this.on('activate',function() {
-        if (typeof Tiny != 'undefined') { MODx.loadRTE('faqman-'+this.ident+'-answer'); }
+        if (MODx.loadRTE) { MODx.loadRTE('faqman-'+this.ident+'-answer'); }
     });
 };
 Ext.extend(faqMan.window.CreateItem,MODx.Window);
@@ -274,7 +275,7 @@ faqMan.window.UpdateItem = function(config) {
         title: _('faqman.item_update')
         ,id: this.ident
         ,autoHeight: true
-        ,width: 600
+        ,width: 650
         ,url: faqMan.config.connector_url
         ,action: 'mgr/item/update'
         ,closeAction: 'close'
@@ -294,11 +295,12 @@ faqMan.window.UpdateItem = function(config) {
             ,name: 'answer'
             ,id: 'faqman-'+this.ident+'-answer'
             ,width: '94%'
+            ,height: 250
         }]
     });
     faqMan.window.UpdateItem.superclass.constructor.call(this,config);
     this.on('activate',function() {
-        if (typeof Tiny != 'undefined') { MODx.loadRTE('faqman-'+this.ident+'-answer'); }
+        if (MODx.loadRTE) { MODx.loadRTE('faqman-'+this.ident+'-answer'); }
     });
 };
 Ext.extend(faqMan.window.UpdateItem,MODx.Window);

--- a/core/components/faqman/controllers/mgr/set.php
+++ b/core/components/faqman/controllers/mgr/set.php
@@ -30,45 +30,21 @@ $modx->regClientStartupScript($faqMan->config['jsUrl'].'mgr/widgets/set.panel.js
 $modx->regClientStartupScript($faqMan->config['jsUrl'].'mgr/sections/set.js');
 $output = '<div id="faqman-panel-set-div"></div>';
 
-/* If we want to use Tiny, we'll need some extra files. */
-$useTiny = $modx->getOption('faqman.use_richtext',$faqMan->config,false);
-if ($useTiny) {
-    $tinyCorePath = $modx->getOption('tiny.core_path',null,$modx->getOption('core_path').'components/tinymce/');
-    /* Make sure Tiny is installed by checking the core class file */
-    if (file_exists($tinyCorePath.'tinymce.class.php')) {
+// See if we need to load a richtext editor.
+$useRichText = $modx->getOption('faqman.use_richtext', $faqMan->config, false);
+$useEditor = $this->modx->getOption('use_editor');
+$whichEditor = $this->modx->getOption('which_editor');
 
-        /* First fetch the faqman+tiny specific settings */
-        $cb1 =  $modx->getOption('faqman.tiny.buttons1',null,'undo,redo,selectall,pastetext,pasteword,charmap,separator,image,modxlink,unlink,media,separator,code,help');
-        $cb2 =  $modx->getOption('faqman.tiny.buttons2',null,'bold,italic,underline,strikethrough,sub,sup,separator,bullist,numlist,outdent,indent,separator,justifyleft,justifycenter,justifyright,justifyfull');
-        $cb3 =  $modx->getOption('faqman.tiny.buttons3',null,'styleselect,formatselect,separator,styleprops');
-        $cb4 =  $modx->getOption('faqman.tiny.buttons4',null,'');
-        $cb5 =  $modx->getOption('faqman.tiny.buttons5',null,'');
-        $plugins =  $modx->getOption('faqman.tiny.custom_plugins',null,'');
-        $theme =  $modx->getOption('faqman.tiny.theme',null,'');
-        $bfs =  $modx->getOption('faqman.tiny.theme_advanced_blockformats',null,'');
-        $css =  $modx->getOption('faqman.tiny.theme_advanced_css_selectors',null,'');
-
-        /* If the settings are empty, override them with the generic tinymce settings. */
-        $tinyProperties = array(
-            'height' => $modx->getOption('faqman.tiny.height',null,200),
-            'width' => $modx->getOption('faqman.tiny.width',null,'95%'),
-            'tiny.custom_buttons1' => (!empty($cb1)) ? $cb1 : $modx->getOption('tiny.custom_buttons1',null,'undo,redo,selectall,separator,pastetext,pasteword,separator,search,replace,separator,nonbreaking,hr,charmap,separator,image,modxlink,unlink,anchor,media,separator,cleanup,removeformat,separator,fullscreen,print,code,help'),
-            'tiny.custom_buttons2' => (!empty($cb2)) ? $cb2 : $modx->getOption('tiny.custom_buttons2',null,'bold,italic,underline,strikethrough,sub,sup,separator,bullist,numlist,outdent,indent,separator,justifyleft,justifycenter,justifyright,justifyfull,separator,styleselect,formatselect,separator,styleprops'),
-            'tiny.custom_buttons3' => (!empty($cb3)) ? $cb3 : $modx->getOption('tiny.custom_buttons3',null,''),
-            'tiny.custom_buttons4' => (!empty($cb4)) ? $cb4 : $modx->getOption('tiny.custom_buttons4',null,''),
-            'tiny.custom_buttons5' => (!empty($cb5)) ? $cb5 : $modx->getOption('tiny.custom_buttons5',null,''),
-            'tiny.custom_plugins' => (!empty($plugins)) ? $plugins : $modx->getOption('tiny.custom_plugins',null,'style,advimage,advlink,modxlink,searchreplace,print,contextmenu,paste,fullscreen,noneditable,nonbreaking,xhtmlxtras,visualchars,media'),
-            'tiny.editor_theme' => (!empty($theme)) ? $theme : $modx->getOption('tiny.editor_theme',null,'cirkuit'),
-            'tiny.skin_variant' => $modx->getOption('tiny.skin_variant',null,''),
-            'tiny.theme_advanced_blockformats' => (!empty($bfs)) ? $bfs : $modx->getOption('tiny.theme_advanced_blockformats',null,'p,h1,h2,h3,h4,h5,h6,div,blockquote,code,pre,address'),
-            'tiny.css_selectors' => (!empty($css)) ? $css : $modx->getOption('tiny.css_selectors',null,''),
-        );
-        require_once $tinyCorePath.'tinymce.class.php';
-        $tiny = new TinyMCE($modx,$tinyProperties);
-        $tiny->setProperties($tinyProperties);
-        $html = $tiny->initialize();
-        $modx->regClientHTMLBlock($html);
+if ($useRichText && $useEditor && !empty($whichEditor)) {
+    // Invoke OnRichTextEditorInit event to prepare RTE
+    $onRichTextEditorInit = $this->modx->invokeEvent('OnRichTextEditorInit',array(
+        'editor' => $whichEditor,
+        'elements' => array(),
+    ));
+    if (is_array($onRichTextEditorInit)) {
+        $onRichTextEditorInit = implode('', $onRichTextEditorInit);
     }
+    $output .= $onRichTextEditorInit;
 }
 
 return $output;


### PR DESCRIPTION
As discussed in josht/faqMan#11 :)

To make it work with Redactor I needed to make a minor change in the Redactor code, which will be part of the upcoming 1.3.2 release. It does work with the current TinyMCE release. 
