### PR TITLE
Prevent enter key submitting the form in windows

### DIFF
--- a/assets/components/faqman/js/mgr/widgets/items.grid.js
+++ b/assets/components/faqman/js/mgr/widgets/items.grid.js
@@ -1,4 +1,3 @@
-
 faqMan.grid.Items = function(config) {
     config = config || {};
 
@@ -257,7 +256,8 @@ faqMan.window.CreateItem = function(config) {
             ,id: 'faqman-'+this.ident+'-answer'
             ,width: '94%'
             ,height: 250
-        }]
+        }],
+        buttons: [] //Prevent enter key from submitting the form
     });
     faqMan.window.CreateItem.superclass.constructor.call(this,config);
     this.on('activate',function() {
@@ -296,7 +296,8 @@ faqMan.window.UpdateItem = function(config) {
             ,id: 'faqman-'+this.ident+'-answer'
             ,width: '94%'
             ,height: 250
-        }]
+        }],
+        buttons: [] //Prevent enter key from submitting the form
     });
     faqMan.window.UpdateItem.superclass.constructor.call(this,config);
     this.on('activate',function() {


### PR DESCRIPTION
When using a RTE such as Redactor, the window has a tendency to submit the form when hitting enter. This breaks the ability to add line breaks in the editor.

This might actually be Redactor-specific as it defaults to an inline editor, while TinyMCE and others default to an iframe and the enter might not trigger in the form.
