### PR TITLE
Fix sort processors for MySQL 8

### DIFF
--- a/core/components/faqman/processors/mgr/item/remove.class.php
+++ b/core/components/faqman/processors/mgr/item/remove.class.php
@@ -57,11 +57,11 @@ class FaqmanItemRemoveProcessor extends modObjectRemoveProcessor {
          */
         $this->modx->exec("
             UPDATE {$this->modx->getTableName($this->classKey)}
-            SET rank = rank - 1
+            SET `rank` = `rank` - 1
             WHERE
             `set` = {$this->set}
-            AND rank > {$this->rank}
-            AND rank > 0
+            AND `rank` > {$this->rank}
+            AND `rank` > 0
         ");
         return true;
     }

--- a/core/components/faqman/processors/mgr/item/sort.class.php
+++ b/core/components/faqman/processors/mgr/item/sort.class.php
@@ -77,22 +77,22 @@ class FaqmanItemSortProcessor extends modObjectUpdateProcessor {
         if ($source->get('rank') < $target->get('rank')) {
             $this->modx->exec("
                 UPDATE {$this->modx->getTableName($this->classKey)}
-                  SET rank = rank - 1
+                  SET `rank` = `rank` - 1
                 WHERE
                   `set` = " . $this->getProperty('set', false) . "
-                AND rank <= {$target->get('rank')}
-                AND rank > {$source->get('rank')}
-                AND rank > 0
+                AND `rank` <= {$target->get('rank')}
+                AND `rank` > {$source->get('rank')}
+                AND `rank` > 0
             ");
             $newRank = $target->get('rank');
         } else {
             $this->modx->exec("
                 UPDATE {$this->modx->getTableName($this->classKey)}
-                  SET rank = rank + 1
+                  SET `rank` = `rank` + 1
                 WHERE
                   `set` = " . $this->getProperty('set', false) . "
-                AND rank >= {$target->get('rank')}
-                AND rank < {$source->get('rank')}
+                AND `rank` >= {$target->get('rank')}
+                AND `rank` < {$source->get('rank')}
             ");
             $newRank = $target->get('rank');
         }

--- a/core/components/faqman/processors/mgr/set/sort.class.php
+++ b/core/components/faqman/processors/mgr/set/sort.class.php
@@ -70,20 +70,20 @@ class FaqmanSetSortProcessor extends modObjectUpdateProcessor {
         if ($source->get('rank') < $target->get('rank')) {
             $this->modx->exec("
                 UPDATE {$this->modx->getTableName($this->classKey)}
-                SET rank = rank - 1
+                SET `rank` = `rank` - 1
                 WHERE
-                rank <= {$target->get('rank')}
-                AND rank > {$source->get('rank')}
-                AND rank > 0
+                `rank` <= {$target->get('rank')}
+                AND `rank` > {$source->get('rank')}
+                AND `rank` > 0
             ");
             $newRank = $target->get('rank');
         } else {
             $this->modx->exec("
                 UPDATE {$this->modx->getTableName($this->classKey)}
-                SET rank = rank + 1
+                SET `rank` = `rank` + 1
                 WHERE
-                rank >= {$target->get('rank')}
-                AND rank < {$source->get('rank')}
+                `rank` >= {$target->get('rank')}
+                AND `rank` < {$source->get('rank')}
             ");
             $newRank = $target->get('rank');
         }


### PR DESCRIPTION
The sort processors don't work correctly in MySQL 8 because _rank_ is a reserved keyword.